### PR TITLE
feat: hash generated from current time to be used for resource name

### DIFF
--- a/src/config/installationHash.ts
+++ b/src/config/installationHash.ts
@@ -1,0 +1,5 @@
+const now = new Date();
+const timestamp = now.getTime(); // Get milliseconds since epoch
+
+// Convert timestamp to base36 (alphanumeric)
+export const installationHash = timestamp.toString(36);


### PR DESCRIPTION
This is a possible addition to the folder structure where all the disparate config files can live.  

Currently, there is a client config from setupCredentials and a VPC config from setupVPC.  Would it make sense that all those files live in a config file together?

Throwing a hash algorithm in here as a test.  

The hash algorithm can be used to generate the hash that will be part of the resource names.