### PR TITLE
feat: convert runners to truly ephemeral

### DIFF
--- a/src/config/configHarrier.ts
+++ b/src/config/configHarrier.ts
@@ -80,9 +80,21 @@ export const configHarrier: configHarrierType = {
   harrierTagValue: "Harrier-Runner",
   ssmSendCommandTimeout: 100,
   maxWaiterTimeInSeconds: 60 * 4,
+  timeoutLambdaDelayInMin: "1",
 
-  backupInstanceTypes: ["m7a.large", "m7i.large", "r7a.medium", "m6a.large", "m6i.large", "m5a.large", "r6a.large", "r5a.large", "r6i.large", "m7a.medium", "t2.micro"],
-
+  backupInstanceTypes: [
+    "m7a.large",
+    "m7i.large",
+    "r7a.medium",
+    "m6a.large",
+    "m6i.large",
+    "m5a.large",
+    "r6a.large",
+    "r5a.large",
+    "r6i.large",
+    "m7a.medium",
+    "t2.micro",
+  ],
 };
 
 export const apiResourcePolicyDocument = JSON.stringify({

--- a/src/config/servicePolicies.ts
+++ b/src/config/servicePolicies.ts
@@ -44,7 +44,11 @@ export const workflowLambdaPolicy = JSON.stringify({
     {
       Sid: "VisualEditor3",
       Effect: "Allow",
-      Action: ["ec2:DescribeInstances", "s3:ListAllMyBuckets"],
+      Action: [
+        "ec2:DescribeInstances",
+        "ec2:RunInstances",
+        "s3:ListAllMyBuckets",
+      ],
       Resource: "*",
     },
     // three new policies:
@@ -62,6 +66,11 @@ export const workflowLambdaPolicy = JSON.stringify({
       Effect: "Allow",
       Action: ["lambda:InvokeFunction"],
       Resource: [`arn:aws:lambda:*:${awsAccountId}:function:harrier*`],
+    },
+    {
+      Effect: "Allow",
+      Action: "iam:PassRole",
+      Resource: "arn:aws:iam::*:role/*",
     },
   ],
 });

--- a/src/config/servicePolicies.ts
+++ b/src/config/servicePolicies.ts
@@ -113,7 +113,7 @@ export const timeoutLambdaPolicy = JSON.stringify({
   Statement: [
     {
       Effect: "Allow",
-      Action: ["s3:GetObject", "s3:PutObject"],
+      Action: ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
       Resource: ["arn:aws:s3:::harrier*/runner-statuses/*"],
     },
     {
@@ -132,7 +132,11 @@ export const timeoutLambdaPolicy = JSON.stringify({
     },
     {
       Effect: "Allow",
-      Action: ["ec2:DescribeInstances", "ec2:StopInstances"],
+      Action: [
+        "ec2:DescribeInstances",
+        "ec2:StopInstances",
+        "ec2:TerminateInstances",
+      ],
       Resource: "*",
     },
   ],

--- a/src/config/servicePolicies.ts
+++ b/src/config/servicePolicies.ts
@@ -47,6 +47,7 @@ export const workflowLambdaPolicy = JSON.stringify({
       Action: [
         "ec2:DescribeInstances",
         "ec2:RunInstances",
+        "ec2:CreateTags",
         "s3:ListAllMyBuckets",
       ],
       Resource: "*",

--- a/src/services/cleanupPrevInstall.ts
+++ b/src/services/cleanupPrevInstall.ts
@@ -3,6 +3,7 @@ import { cleanupLambdas } from "../utils/aws/cleanup/cleanupLambdas";
 import { cleanupApi } from "../utils/aws/cleanup/cleanupApi";
 import { cleanupIamRoles } from "../utils/aws/cleanup/cleanupIamRoles";
 import { cleanupS3 } from "../utils/aws/cleanup/cleanupS3";
+import { cleanupEventbridge } from "../utils/aws/cleanup/cleanupEventbridge";
 import { cleanupVpc } from "../utils/aws/cleanup/cleanupVpc";
 
 // Cleanup function to delete Lambdas, API Gateway REST APIs, and associated IAM roles
@@ -14,6 +15,7 @@ export const cleanupPrevInstall = async () => {
     await cleanupApi();
     await cleanupIamRoles();
     await cleanupS3();
+    await cleanupEventbridge();
     await cleanupVpc();
 
     console.log("✅ Harrier Cleanup complete.\n");

--- a/src/types/typesConfig.ts
+++ b/src/types/typesConfig.ts
@@ -50,6 +50,7 @@ export interface configHarrierType {
   harrierTagValue: string;
   ssmSendCommandTimeout: number;
   maxWaiterTimeInSeconds: number;
+  timeoutLambdaDelayInMin: string;
 
   backupInstanceTypes: _InstanceType[];
 }

--- a/src/utils/aws/cleanup/cleanupApi.ts
+++ b/src/utils/aws/cleanup/cleanupApi.ts
@@ -3,8 +3,9 @@ import {
   GetRestApisCommand,
   DeleteRestApiCommand,
 } from "@aws-sdk/client-api-gateway";
+import { configHarrier } from "../../../config/configHarrier";
 
-const apiGatewayClient = new APIGatewayClient({ region: "us-east-1" });
+const apiGatewayClient = new APIGatewayClient({ region: configHarrier.region });
 
 // Function to delete API Gateway REST APIs with names starting with "Harrier"
 export const cleanupApi = async () => {

--- a/src/utils/aws/cleanup/cleanupEC2s.ts
+++ b/src/utils/aws/cleanup/cleanupEC2s.ts
@@ -4,8 +4,9 @@ import {
   TerminateInstancesCommand,
   DeleteSecurityGroupCommand,
 } from "@aws-sdk/client-ec2";
+import { configHarrier } from "../../../config/configHarrier";
 
-const ec2Client = new EC2Client({ region: "us-east-1" }); // specify your region
+const ec2Client = new EC2Client({ region: configHarrier.region }); // specify your region
 
 // Find EC2 instances by prefix
 const getInstancesByNamePrefix = async (prefix: string) => {

--- a/src/utils/aws/cleanup/cleanupEC2s.ts
+++ b/src/utils/aws/cleanup/cleanupEC2s.ts
@@ -42,7 +42,9 @@ const getInstancesByNamePrefix = async (prefix: string) => {
             instance.SecurityGroups.forEach((group) => {
               if (group.GroupId) {
                 console.log("      Found security group: ", group.GroupId);
-                securityGroups.push(group.GroupId);
+                if (!securityGroups.includes(group.GroupId)) {
+                  securityGroups.push(group.GroupId);
+                }
               }
             });
           }

--- a/src/utils/aws/cleanup/cleanupEventbridge.ts
+++ b/src/utils/aws/cleanup/cleanupEventbridge.ts
@@ -1,0 +1,65 @@
+import {
+  SchedulerClient,
+  ListSchedulesCommand,
+  DeleteScheduleCommand,
+  ScheduleSummary,
+} from "@aws-sdk/client-scheduler";
+import { configHarrier } from "../../../config/configHarrier";
+
+const client = new SchedulerClient({ region: configHarrier.region });
+
+const getScheduleByNamePrefix = async (prefix: string) => {
+  try {
+    const command = new ListSchedulesCommand({});
+    const response = await client.send(command);
+
+    const harrierSchedules = (response.Schedules || []).filter((schedule) =>
+      schedule.Name?.startsWith(prefix)
+    );
+
+    return harrierSchedules;
+  } catch (error) {
+    console.error("❌ Error: ", error, "\n");
+    throw new Error("❌ Error finding Harrier Eventbridge schedules!");
+  }
+};
+
+const deleteSchedules = async (schedules: ScheduleSummary[]) => {
+  try {
+    for (const schedule of schedules) {
+      const scheduleName = schedule.Name;
+      console.log("   Deleting schedule: ", scheduleName);
+
+      const deleteParams = { Name: scheduleName };
+      const deleteCommand = new DeleteScheduleCommand(deleteParams);
+      await client.send(deleteCommand);
+      console.log("   Successfully deleted schedule: ", scheduleName);
+    }
+  } catch (error) {
+    console.error(
+      "❌ Error deleting Harrier Eventbridge schedules!: ",
+      error,
+      "\n"
+    );
+  }
+};
+
+export const cleanupEventbridge = async () => {
+  try {
+    console.log("** Start Eventbridge Schedule cleanup");
+
+    // Step 1: Find all Harrier Eventbridge schedules
+    const harrierSchedules = await getScheduleByNamePrefix("harrier");
+
+    if (harrierSchedules.length === 0) {
+      console.log("   No schedules to delete.");
+    } else {
+      //Step 2: Delete all Harrier Eventbridge schedules
+      await deleteSchedules(harrierSchedules);
+    }
+
+    console.log("✅ Successfully completed Eventbridge Schedule cleanup.\n");
+  } catch (error) {
+    console.error("❌ Error cleaning up Eventbridge Schedules: ", error, "\n");
+  }
+};

--- a/src/utils/aws/cleanup/cleanupIamRoles.ts
+++ b/src/utils/aws/cleanup/cleanupIamRoles.ts
@@ -7,8 +7,9 @@ import {
   ListRolesCommand,
   DeleteRoleCommand,
 } from "@aws-sdk/client-iam";
+import { configHarrier } from "../../../config/configHarrier";
 
-const iamClient = new IAMClient({ region: "us-east-1" });
+const iamClient = new IAMClient({ region: configHarrier.region });
 
 // Function to detach managed policies from a role
 async function detachManagedPolicies(roleName: string) {

--- a/src/utils/aws/cleanup/cleanupS3.ts
+++ b/src/utils/aws/cleanup/cleanupS3.ts
@@ -5,9 +5,10 @@ import {
   DeleteObjectsCommand,
   DeleteBucketCommand,
 } from "@aws-sdk/client-s3";
+import { configHarrier } from "../../../config/configHarrier";
 
 // Create an S3 client
-const s3Client = new S3Client({ region: "us-east-1" }); // Change to your region
+const s3Client = new S3Client({ region: configHarrier.region }); // Change to your region
 
 // Function to find all S3 buckets whose name starts with "Harrier"
 const findBucketsWithPrefix = async (prefix: string) => {

--- a/src/utils/aws/cleanup/cleanupVpc.ts
+++ b/src/utils/aws/cleanup/cleanupVpc.ts
@@ -8,9 +8,10 @@ import {
   DetachInternetGatewayCommand,
   DeleteInternetGatewayCommand,
 } from "@aws-sdk/client-ec2";
+import { configHarrier } from "../../../config/configHarrier";
 
 // Create EC2 client
-const ec2Client = new EC2Client({ region: "us-east-1" }); // Replace with your region
+const ec2Client = new EC2Client({ region: configHarrier.region }); // Replace with your region
 
 // Find all VPCs whose name starts with "Harrier"
 const findVpcsWithNamePrefix = async (prefix: string) => {

--- a/src/utils/aws/lambda/createAndDeployLambda.ts
+++ b/src/utils/aws/lambda/createAndDeployLambda.ts
@@ -44,6 +44,7 @@ export async function createAndDeployLambda(
             configHarrier.maxWaiterTimeInSeconds
           ),
           TIMEOUT_LAMBDA_NAME: configHarrier.timeoutLambdaName,
+          TIMEOUT_LAMBDA_DELAY: configHarrier.timeoutLambdaDelayInMin,
         },
       },
       Runtime: "nodejs20.x",

--- a/src/utils/aws/s3/initializeEC2Status.ts
+++ b/src/utils/aws/s3/initializeEC2Status.ts
@@ -7,21 +7,35 @@ export const initializeEC2Status = async () => {
   const statusObject = {
     status: "offline",
   };
-  const jsonString = JSON.stringify(statusObject);
+  const statusString = JSON.stringify(statusObject);
 
   const EC2InstanceIds = configHarrier.instanceIds;
+
+  const nextIDObject = {
+    nextId: EC2InstanceIds.length,
+  };
+  const nextIDString = JSON.stringify(nextIDObject);
 
   try {
     for (const instanceId of EC2InstanceIds) {
       const command = new PutObjectCommand({
         Bucket: configHarrier.s3Name,
         Key: `runner-statuses/${instanceId}.json`,
-        Body: jsonString,
+        Body: statusString,
         ContentType: "application/json",
       });
 
       await client.send(command);
     }
+
+    const command = new PutObjectCommand({
+      Bucket: configHarrier.s3Name,
+      Key: `runner-statuses/nextId.json`,
+      Body: nextIDString,
+      ContentType: "application/json",
+    });
+
+    await client.send(command);
 
     console.log(`✅ Successfully initialized S3 with EC2 status "offline".\n`);
   } catch (error) {

--- a/src/utils/aws/s3/initializeEC2Status.ts
+++ b/src/utils/aws/s3/initializeEC2Status.ts
@@ -7,13 +7,13 @@ export const initializeEC2Status = async () => {
   const statusObject = {
     status: "offline",
     lastRun: {
-      timeStamp: "",
-      user: "",
-      organization: "",
-      repository: "",
-      branch: "",
-      workflow: "",
-      job: "",
+      // timeStamp: "",
+      // user: "",
+      // organization: "",
+      // repository: "",
+      // branch: "",
+      // workflow: "",
+      // job: "",
     },
   };
   const statusString = JSON.stringify(statusObject);

--- a/src/utils/aws/s3/initializeEC2Status.ts
+++ b/src/utils/aws/s3/initializeEC2Status.ts
@@ -6,6 +6,15 @@ export const initializeEC2Status = async () => {
 
   const statusObject = {
     status: "offline",
+    lastRun: {
+      timeStamp: "",
+      user: "",
+      organization: "",
+      repository: "",
+      branch: "",
+      workflow: "",
+      job: "",
+    },
   };
   const statusString = JSON.stringify(statusObject);
 

--- a/static/lambdas/timeout/index.mjs
+++ b/static/lambdas/timeout/index.mjs
@@ -1,10 +1,13 @@
-import { EC2Client, StopInstancesCommand } from "@aws-sdk/client-ec2";
+import {
+  EC2Client,
+  StopInstancesCommand,
+  TerminateInstancesCommand,
+} from "@aws-sdk/client-ec2";
 import {
   S3Client,
   GetObjectCommand,
   // PutObjectCommand,
   DeleteObjectCommand,
-  TerminateInstancesCommand,
 } from "@aws-sdk/client-s3";
 const REGION = process.env.AWS_REGION;
 const [ec2Client, s3Client] = [EC2Client, S3Client].map(

--- a/static/lambdas/workflow/index.mjs
+++ b/static/lambdas/workflow/index.mjs
@@ -300,7 +300,7 @@ async function checkInstanceStatus(
       const { timeStamp: lastTimeStamp, ...lastRun } = instanceState.lastRun;
       const { timeStamp: currentTimeStamp, ...currentRun } = runDetails;
 
-      for (const property of currentRun) {
+      for (const property of Object.keys(currentRun)) {
         if (lastRun[property] !== currentRun[property]) {
           return false;
         }

--- a/static/lambdas/workflow/index.mjs
+++ b/static/lambdas/workflow/index.mjs
@@ -594,7 +594,7 @@ async function createEC2(instanceProps, nextPoolId) {
 async function waitEC2StatusOk(instanceIds) {
   try {
     console.log("Waiting until STATUS OK...");
-    const MAX_WAITER_TIME_IN_SECONDS = 60 * 6;
+    const MAX_WAITER_TIME_IN_SECONDS = 60 * 3;
     const startTime = new Date();
     await waitUntilInstanceStatusOk(
       {

--- a/static/lambdas/workflow/index.mjs
+++ b/static/lambdas/workflow/index.mjs
@@ -7,6 +7,8 @@ import {
   DescribeInstancesCommand,
   StartInstancesCommand,
   waitUntilInstanceRunning,
+  RunInstancesCommand,
+  waitUntilInstanceStatusOk,
 } from "@aws-sdk/client-ec2";
 
 import {
@@ -424,6 +426,228 @@ async function describeInstance(instanceId) {
   }
 }
 
+async function getNextEC2PoolId(s3BucketName) {
+  try {
+    const response = await s3Client.send(
+      new GetObjectCommand({
+        Bucket: s3BucketName,
+        Key: "runner-statuses/nextId.json",
+      })
+    );
+
+    const bodyString = await streamToString(response.Body);
+    const nextId = JSON.parse(bodyString).nextId;
+
+    return nextId;
+  } catch (error) {
+    console.error(`Error fetching next EC2 pool ID: `, error);
+    throw error;
+  }
+}
+
+function makeScriptForNewEC2() {
+  return `#!/bin/bash
+  echo "Starting setup.sh script"
+
+  # Update the package list
+  sudo apt-get update -y
+
+  echo "cd /home/"
+  cd /home/
+  echo "cd ubuntu"
+  cd ubuntu
+
+  # Install jq
+  sudo apt install -y jq
+
+   # Install build-essentials
+  echo "%%%% before build-essentials install %%%%";
+  sudo apt install -y build-essential
+  echo "%%%% after build-essentials install %%%%";
+
+  # Install GitHub Actions Self-Hosted Runner
+  # Create a folder and switch to it.
+  echo "mkdir actions-runner"
+  mkdir actions-runner
+
+  #cd ..
+  sudo chown ubuntu:ubuntu ./actions-runner
+  cd actions-runner
+
+  # Download the latest runner package
+  echo "DOWNLOAD GITHUB ACTIONS RUNNER"
+  curl -o actions-runner-linux-x64-2.320.0.tar.gz -L https://github.com/actions/runner/releases/download/v2.320.0/actions-runner-linux-x64-2.320.0.tar.gz
+  # Extract the installer
+  echo "*** EXTRACT GITHUB ACTIONS RUNNER ***"
+  tar xzf ./actions-runner-linux-x64-2.320.0.tar.gz
+
+  # Need to install this to get .config.sh to work
+  echo "*** INSTALL LIBICU ***"
+  sudo apt update && sudo apt install -y libicu-dev
+
+  # Install Git
+  echo "*** INSTALL GIT ***"
+  sudo apt install -y git
+
+  # Download Mountpoint
+  echo "**** DOWNLOAD MOUNTPOINT ***"
+  sudo wget https://s3.amazonaws.com/mountpoint-s3-release/latest/x86_64/mount-s3.deb
+
+  # install Mountpoint
+  echo "**** INSTALL MOUNTPOINT ***"
+  sudo apt install -y ./mount-s3.deb
+
+  echo "**** MKDIR S3BUCKET ***"
+  mkdir s3bucket
+  sudo chown ubuntu:ubuntu ./s3bucket
+  echo "**** SUDO MKDIR S3BUCKET ***"
+  sudo mkdir s3bucket
+
+  echo "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
+  echo "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
+  # Install Docker
+  echo "INSTALL DOCKER"
+  #sudo dnf install -y docker
+  sudo apt-get install -y docker.io
+  echo "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
+
+  # Give current user some permissions
+  echo "Give current user some permissions!!!!"
+  echo $USER
+  echo "*** CALL - sudo usermod -aG docker $USER ***"
+  sudo usermod -aG docker $USER
+  sudo usermod -aG docker ubuntu
+  echo "*** ALSO TRY - usermod -aG docker $USER ***"
+  usermod -aG docker $USER
+  usermod -aG docker ubuntu
+  echo "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
+  echo "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
+
+  # Start Docker deamon and set to start-up on reboots
+  echo "START DOCKER DAEMON AND SET TO START-UP AUTOMATICALLY ON REBOOTS"
+  sudo systemctl start docker
+  sudo systemctl enable docker
+  groups
+  getent group docker
+  echo "!!!!!!!!  END OF START SCRIPT !!!!!!"`;
+}
+
+async function createEC2(instanceProps, nextPoolId) {
+  const userDataScript = makeScriptForNewEC2();
+  const userData = Buffer.from(userDataScript).toString("base64");
+
+  const params = {
+    ImageId: instanceProps.amiId, // AMI ID for the instance
+    InstanceType: instanceProps.instanceType, // EC2 instance type
+    KeyName: instanceProps.keyName,
+    MinCount: 1, // Minimum instances to launch
+    MaxCount: 1, // Maximum instances to launch
+    BlockDeviceMappings: [
+      {
+        DeviceName: "/dev/sda1",
+        Ebs: {
+          VolumeSize: 16, // Size of the volume in GB
+          VolumeType: "gp3",
+        },
+      },
+    ],
+    SecurityGroupIds: instanceProps.securityGroupIds, // Security group IDs
+    SubnetId: instanceProps.subnetId, // Subnet ID (optional)
+    IamInstanceProfile: instanceProps.iamInstanceProfile, // IAM resource profile
+    TagSpecifications: [
+      {
+        ResourceType: "instance",
+        Tags: [
+          {
+            Key: "Name",
+            Value: `harrier-${instanceProps.harrierHash}-ec2-${nextPoolId}`,
+          },
+          { Key: "Agent", Value: "Harrier-Runner" },
+        ],
+      },
+    ], // Instance tags
+    UserData: userData, // UserData (must be base64 encoded)
+  };
+
+  const runInstancesCommand = new RunInstancesCommand(params);
+
+  try {
+    const instanceData = await ec2Client.send(runInstancesCommand);
+    const instanceId = instanceData.Instances[0].InstanceId;
+
+    console.log(`✅ Successfully created instance with ID: ${instanceId}\n`);
+    return instanceId;
+  } catch (error) {
+    throw new Error(`❌ Error creating EC2 instance: ${error}`);
+  }
+}
+
+async function waitEC2StatusOk(instanceIds) {
+  try {
+    console.log("Waiting until STATUS OK...");
+    const MAX_WAITER_TIME_IN_SECONDS = 60 * 8;
+    const startTime = new Date();
+    await waitUntilInstanceStatusOk(
+      {
+        client: client,
+        maxWaitTime: MAX_WAITER_TIME_IN_SECONDS,
+      },
+      { InstanceIds: instanceIds }
+    );
+    const endTime = new Date();
+    console.log(
+      "✅ STATUS OK Succeeded after time: ",
+      (endTime.getTime() - startTime.getTime()) / 1000
+    );
+  } catch (error) {
+    error.message = `${error.message}. Try increasing the maxWaitTime in the waiter.`;
+    console.error(error);
+  }
+}
+
+async function stopEC2s(instanceIds) {
+  try {
+    const command = new StopInstancesCommand({ InstanceIds: instanceIds });
+    const response = await ec2Client.send(command);
+    console.log("Stopping instance:", response.StoppingInstances);
+  } catch (error) {
+    console.error("❌ Error stopping instance:", error);
+  }
+}
+
+async function setupNextEC2(instanceProps, nextPoolId) {
+  try {
+    const instanceId = await createEC2(instanceProps, nextPoolId);
+    const instanceIds = [instanceId];
+    await waitEC2StatusOk(instanceIds);
+    await stopEC2s(instanceIds);
+  } catch (error) {
+    console.error(`Error creating next EC2: `, error);
+    throw error;
+  }
+}
+
+async function incrementNextEC2PoolId(s3BucketName, nextPoolId) {
+  try {
+    const nextIDObject = {
+      nextId: EC2InstanceIds.length,
+    };
+    const nextIDString = JSON.stringify(nextIDObject);
+
+    const command = new PutObjectCommand({
+      Bucket: s3BucketName,
+      Key: `runner-statuses/nextId.json`,
+      Body: nextIDString,
+      ContentType: "application/json",
+    });
+
+    await s3client.send(command);
+    console.log("Successfully updated next EC2 pool ID to: ", nextPoolId);
+  } catch (error) {
+    console.error("Error updating next EC2 pool ID: ", error);
+  }
+}
+
 async function invokeTimeoutLambda(
   instanceId,
   delayInMinutes,
@@ -534,6 +758,13 @@ export const handler = async (event) => {
 
           const instanceProps = await describeInstance(instanceId);
           console.log({ instanceProps });
+
+          const nextPoolId = await getNextEC2PoolId(s3BucketName);
+          console.log(nextPoolId);
+
+          await setupNextEC2(instanceProps, nextPoolId);
+
+          await incrementNextEC2PoolId(s3BucketName, nextPoolId + 1);
         } else {
           // this should never be reached...
           console.log(`⚠️ this line should never be reached`);

--- a/static/lambdas/workflow/index.mjs
+++ b/static/lambdas/workflow/index.mjs
@@ -390,7 +390,7 @@ async function updateInstanceStatus(
 
     const statusObject = {
       status: nextStatus,
-      lastRun: { lastRunDetails },
+      lastRun: lastRunDetails,
     };
     const statusString = JSON.stringify(statusObject);
     await s3Client.send(

--- a/static/lambdas/workflow/index.mjs
+++ b/static/lambdas/workflow/index.mjs
@@ -650,7 +650,7 @@ async function updateEC2PoolStatus(s3BucketName, nextPoolId, nextInstanceId) {
     const statusString = JSON.stringify(statusObject);
 
     const statusCommand = new PutObjectCommand({
-      Bucket: configHarrier.s3Name,
+      Bucket: s3BucketName,
       Key: `runner-statuses/${nextInstanceId}.json`,
       Body: statusString,
       ContentType: "application/json",

--- a/static/lambdas/workflow/index.mjs
+++ b/static/lambdas/workflow/index.mjs
@@ -35,6 +35,7 @@ const {
   SSM_SEND_COMMAND_TIMEOUT, // these are both strings
   MAX_WAITER_TIME_IN_SECONDS,
   TIMEOUT_LAMBDA_NAME,
+  TIMEOUT_LAMBDA_DELAY,
 } = process.env;
 
 const [secretClient, ssmClient, ec2Client, s3Client, lambdaClient] = [
@@ -828,7 +829,7 @@ export const handler = async (event) => {
         break;
       case "completed":
         const existingEC2RunnerInstanceId = event.workflow_job.runner_name; // @wook this value seems to be undefined
-        const delay = 1; // wait 1 minute
+        const delay = parseInt(TIMEOUT_LAMBDA_DELAY, 10); // wait time set by user, default 1 minute
 
         // Workflow completed should indicate that the EC2 is no longer running a job, thus need to toggle state to "idle"
         await updateInstanceStatus(


### PR DESCRIPTION
Provision brand new EC2 whenever one is started up from the warm pool.

Terminate EC2 after a standby period.

Effectively, create an EC2 checkout system where a user can check out an EC2 for a short duration to work on one specific project, which will then auto terminate to prevent data leakage.